### PR TITLE
Fix "Unable to generate the TLM marker segments..." errors for some input files

### DIFF
--- a/src/main/cpp/kduc.h
+++ b/src/main/cpp/kduc.h
@@ -78,6 +78,7 @@ class mem_compressed_target : public kdu_core::kdu_compressed_target {
       return false;
 
     this->backtrack = backtrack;
+    return true;
   }
 
   bool end_rewrite() {


### PR DESCRIPTION
FFMPEG / KDU was generating TLM write errors for some input files. 

I tracked the issue down to this missing return statement.